### PR TITLE
Send an "ok" when ready to start invoking

### DIFF
--- a/go/edgefunction/server.go
+++ b/go/edgefunction/server.go
@@ -34,6 +34,9 @@ func Start(handler interface{}) {
 	defer file.Close()
 
 	handlerWrapper := NewHandler(handler)
+	r := &invokeResponseWrapper{}
+	r.Payload, _ = json.Marshal("ok")
+	writeResponse(r, file)
 
 	for {
 		processRequest(handlerWrapper, file)


### PR DESCRIPTION
Accounts for changes in the edgefunctions platform, requiring a runtime to send a ready signal ("ok") when the runtime is ready to start receiving invocations. 